### PR TITLE
fixed scaling on small map sizes

### DIFF
--- a/extension/drawer.js
+++ b/extension/drawer.js
@@ -41,7 +41,7 @@ class Drawer {
         this.canvas.style.left = this.originalCanvas.style.left;
         this.canvas.style.width = this.originalCanvas.style.width;
         this.canvas.style.height = this.originalCanvas.style.height;
-        this.scale = this.canvas.clientWidth / (viewport.right - viewport.left + 1);
+        this.scale = this.canvas.clientWidth / (viewport.right - viewport.left);
         this.ctx.setTransform(
             this.scale, 0,
             0, this.scale,

--- a/extension/knownGames.js
+++ b/extension/knownGames.js
@@ -135,11 +135,11 @@ function createViewportFromScreenshot(
     let logicalRight = screenLogicalWidth - logicalLeft;
     let logicalBottom = screenLogicalHeight - logicalTop;
     return {
-        left: -Math.round(logicalLeft),
-        top: -Math.round(logicalTop),
-        right: Math.round(logicalRight),
-        bottom: Math.round(logicalBottom),
+        left: -logicalLeft,
+        top: -logicalTop,
+        right: logicalRight,
+        bottom: logicalBottom,
         fieldWidth: fieldLogicalWidth,
-        fieldHeight: Math.round((fieldLogicalWidth * 9) / 16),
+        fieldHeight: (fieldLogicalWidth * 9) / 16,
     };
 }


### PR DESCRIPTION
На маленьких значениях размера поля координаты съезжают в разные стороны, после исправления оказалось что масштабирование также учитывает дополнительный пиксель который на меленьких значениях превращается в клетку.

Проверял и тестировал на [Crystal Rush](https://www.codingame.com/ide/puzzle/crystal-rush) командами:
```
!vp 30 600 1233 15834
@l #0FF 0 0 30 15
```

Вычисления границ вычислял в пикселях на скриншоте с последующим масштабированием до 
```kotlin
fun viewport(
    fieldLogicalWidth: Int,
    marginLeft: Int,
    marginTop: Int,
    marginRight: Int
) {
    System.err.println("!vp $fieldLogicalWidth ${marginLeft * 25 / 3} ${marginTop * 25 / 3} ${16000 - marginRight * 25 / 3}")
}

viewport(30, 72, 148, 20)
```

До патча:
![image](https://github.com/xoposhiy/cg-overlays/assets/4599661/92e80f27-ceeb-47ff-ab28-a6b23d6abbdf)

После патча:
![image](https://github.com/xoposhiy/cg-overlays/assets/4599661/4e80041b-c063-4955-8fbd-829cc904df7c)