### PR TITLE
Fixed canvas overlay duplication

### DIFF
--- a/extension/contentScript.js
+++ b/extension/contentScript.js
@@ -78,6 +78,10 @@ function main() {
 			return;
 		}
 		let originalCanvas = canvasContainer.children[0];
+		let existingOverlay = document.getElementById('cgOverlayCanvas');
+		if (existingOverlay != null) {
+			existingOverlay.remove();
+		}
 		let canvas = document.createElement('canvas');
 		canvas.id = "cgOverlayCanvas";
 		canvas.style.position = 'absolute';


### PR DESCRIPTION
Opening "Last Battles" tab leads to canvas overlay duplication and older drawings not cleared:

![image](https://github.com/xoposhiy/cg-overlays/assets/398556/a6192281-f9cb-437b-b2a5-10cdc26c4cbd)


![image](https://github.com/xoposhiy/cg-overlays/assets/398556/4dc09b13-a91f-4ddf-b7ec-49cd6ae36c8d)
